### PR TITLE
Fix a panic when the provided iban length is less than 2 characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,11 @@ pub fn validate<I: AsRef<str>>(input: I) -> Result<Iban, ValidationError> {
         return Err(ValidationError::InvalidChar);
     };
 
+    // IBAN must have at least 2 characters to match a country code.
+    if input.len() < 2 {
+        return Err(ValidationError::InvalidCountryCode);
+    };
+
     // See if it is a valid Country
     let country_code = &input[0..2];
     let country = match Country::from_str(country_code) {

--- a/tests/iban.rs
+++ b/tests/iban.rs
@@ -83,3 +83,8 @@ fn validate_iban_basic() {
     validate("IQ98 NBIQ 8501 2345 6789 012").unwrap(); // Iraq
     validate("AA11 0011 123Z 5678").unwrap(); // Internet
 }
+
+#[test]
+fn validate_iban_empty() {
+    assert!(matches!(validate(""), Err(ValidationError::InvalidCountryCode)));
+}

--- a/tests/iban.rs
+++ b/tests/iban.rs
@@ -87,4 +87,6 @@ fn validate_iban_basic() {
 #[test]
 fn validate_iban_empty() {
     assert!(matches!(validate(""), Err(ValidationError::InvalidCountryCode)));
+    assert!(matches!(validate("F"), Err(ValidationError::InvalidCountryCode)));
+    assert!(matches!(validate("FR"), Err(ValidationError::InvalidLength)));
 }


### PR DESCRIPTION
I found an issue while using the lib, the `validate` function would panic if given an empty string.

I added a safety check to prevent that from happening. Also added a unit test.

Let me know if the proposed solution need some changes.

I would be thankful if you could release a new version of the lib on crates.io with this fix when it's merged 🙏 